### PR TITLE
Remove language-rust as a package dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "ide"
   ],
   "package-deps": [
-    "language-rust",
     "atom-ide-ui"
   ],
   "engines": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "atom-ide-ui"
   ],
   "engines": {
-    "atom": ">=1.21.0"
+    "atom": ">=1.33.0"
   },
   "dependencies": {
     "atom-languageclient": "^0.9.8",


### PR DESCRIPTION
Built-in support for Rust syntax is amazing thanks to tree-sitter