### PR TITLE
Avoid notifying about rlsCommandOverride being 'rls'

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -627,7 +627,9 @@ class RustLanguageClient extends AutoLanguageClient {
 
     let cmdOverride = rlsCommandOverride()
     if (cmdOverride) {
-      if (!this._warnedAboutRlsCommandOverride) {
+      if (!this._warnedAboutRlsCommandOverride && cmdOverride !== 'rls') {
+        // Don't warn if literally 'rls' as this is a workaround for no-rustup environments
+        // TODO: Remove !== 'rls' check once better no-rustup support is in
         clearIdeRustInfos()
         atom.notifications.addInfo(`Using rls command \`${cmdOverride}\``)
         this._warnedAboutRlsCommandOverride = true


### PR DESCRIPTION
Fixes #114 

Better support for no-rustup envs should come later, see #115