### PR TITLE
Show error notification for rustup update failures

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -342,7 +342,13 @@ class RustLanguageClient extends AutoLanguageClient {
             .then(() => this._checkToolchain())
             .then(() => checkRls())
             .then(() => this._restartLanguageServers(`Updated Rls toolchain`))
-            .catch(logErr)
+            .catch(e => {
+              logErr(e)
+              e && atom.notifications.addError(`\`rustup update ${toolchain}\` failed`, {
+                detail: e,
+                dismissable: true,
+              })
+            })
 
           if (this.busySignalService) {
             this.busySignalService.reportBusyWhile(


### PR DESCRIPTION
Today's nightly fails when calling rustup update. Previously this kind of error was only logged. This change shows the error as a notification, which makes sense as the user will have clicked to update the toolchain.

![](https://user-images.githubusercontent.com/2331607/50962086-60fdcc00-14c1-11e9-8af7-9b301e45ce5f.png)
