### PR TITLE
Support out-of-project files

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -594,6 +594,10 @@ class RustLanguageClient extends AutoLanguageClient {
       !filePath.includes('/target/release/')
   }
 
+  serversSupportDefinitionDestinations() {
+    return true
+  }
+
   async startServerProcess(projectPath) {
     if (shouldIgnoreProjectPath(projectPath)) {
       console.warn("ide-rust disabled on", projectPath)

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,9 +85,8 @@
       "dev": true
     },
     "atom-languageclient": {
-      "version": "0.9.9",
-      "resolved": "https://registry.npmjs.org/atom-languageclient/-/atom-languageclient-0.9.9.tgz",
-      "integrity": "sha512-eAKLFhprcDksPtDtG2lrhQEosNMxEbS7MISpw7n6TIoPmTgolvo+GPAF+nSV+Z9MCss91i+M+TNk9Mj5C7y/CQ==",
+      "version": "github:alexheretic/atom-languageclient#ea4c49d7523becb373ca9066e2a6ad5f0888bc81",
+      "from": "github:alexheretic/atom-languageclient#build",
       "requires": {
         "fuzzaldrin-plus": "^0.6.0",
         "vscode-jsonrpc": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "atom": ">=1.33.0"
   },
   "dependencies": {
-    "atom-languageclient": "^0.9.9",
+    "atom-languageclient": "alexheretic/atom-languageclient#build",
     "atom-package-deps": "^5.0.0",
     "toml": "^3.0.0",
     "underscore-plus": "^1.6.8"


### PR DESCRIPTION
I've proposed [support for out-of-project files upstream](https://github.com/atom/atom-languageclient/pull/253). This provides language server support for cargo dependencies and the std library.

With the state of atom-languageclient I assume this will rest unmerged for the foreseeable future so ide-rust will now use a fork: `alexheretic/atom-languageclient#build`

Fixes #96

![](https://user-images.githubusercontent.com/2331607/52712284-065a0300-2f8c-11e9-8735-e991ef47aa53.gif)
