### PR TITLE
Switch to stable toolchain by default

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -266,7 +266,7 @@ class RustLanguageClient extends AutoLanguageClient {
         description: 'Sets the toolchain installed using rustup and used to run the Rls.' +
           ' For example ***nightly***, ***stable***, ***beta***, or ***nightly-yyyy-mm-dd***.',
         type: 'string',
-        default: 'nightly',
+        default: 'stable',
         order: 1
       },
       checkForToolchainUpdates: {


### PR DESCRIPTION
Switch to the stable toolchain by default with the 1.34 release.

Resolves #128