### PR TITLE
Support use of rustup default toolchain & overrides

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,11 +16,11 @@ const { showConflictingPackageWarnings } = require("./competition.js")
 /** @type {number} interval between toolchain update checks, milliseconds */
 const PERIODIC_UPDATE_CHECK_MILLIS = 6 * 60 * 60 * 1000
 
-async function exec(command) {
+async function exec(command, { cwd }={}) {
   return new Promise((resolve, reject) => {
     const env = process.env
     env.PATH = envPath()
-    cp.exec(command, { env }, (err, stdout, stderr) => {
+    cp.exec(command, { env, cwd }, (err, stdout, stderr) => {
       if (err != null) {
         reject(err)
         return
@@ -78,6 +78,15 @@ function configToolchain() {
   return atom.config.get('ide-rust.rlsToolchain')
 }
 
+function rustupRun(toolchain, command, opts={}) {
+  return toolchain && exec(`rustup run ${toolchain} ${command}`, opts) || exec(`${command}`, opts)
+}
+
+async function rustupDefaultToolchain() {
+  let { stdout } = await exec("rustup default")
+  return stdout.split("-")[0].trim()
+}
+
 /** @return {?string} developer override of the command to start a Rls instance */
 function rlsCommandOverride() {
   return atom.config.get('ide-rust.rlsCommandOverride')
@@ -100,17 +109,18 @@ function shouldIgnoreProjectPath(projectPath) {
 }
 
 /**
- * @param {string} toolchain
+ * @param {string} [toolchain]
+ * @param {string} [cwd]
  * @return {Promise<string>} `rustc --print sysroot` stdout
  */
-async function rustcSysroot(toolchain) {
+async function rustcSysroot(toolchain, cwd) {
   try {
-    let { stdout } = await exec(`rustup run ${toolchain} rustc --print sysroot`)
+    let { stdout } = await rustupRun(toolchain, "rustc --print sysroot", { cwd })
     return stdout.trim()
   } catch (e) {
     // make an attempt to use system rustc
     try {
-      let { stdout } = await exec(`rustc --print sysroot`)
+      let { stdout } = await exec(`rustc --print sysroot`, { cwd })
       return stdout.trim()
     } catch (sys_e) {
       throw e
@@ -129,9 +139,10 @@ let envPath = () => {
 
 /**
  * @param {string} [toolchain]
+ * @param {string} [cwd]
  * @return {Promise<object>} environment vars
  */
-async function serverEnv(toolchain) {
+async function serverEnv(toolchain, cwd) {
   const env = process.env
   env.PATH = envPath()
   env.RUST_BACKTRACE = env.RUST_BACKTRACE || "1"
@@ -140,13 +151,11 @@ async function serverEnv(toolchain) {
     env.RUST_LOG = 'rls=warn,rls::build=info'
   }
 
-  if (toolchain) {
-    try {
-      let sysroot = await rustcSysroot(toolchain)
-      env.RUST_SRC_PATH = path.join(sysroot, "/lib/rustlib/src/rust/src/")
-    } catch (e) {
-      console.warn("Failed to find sysroot: " + e)
-    }
+  try {
+    let sysroot = await rustcSysroot(toolchain, cwd)
+    env.RUST_SRC_PATH = path.join(sysroot, "/lib/rustlib/src/rust/src/")
+  } catch (e) {
+    console.warn("Failed to find sysroot: " + e)
   }
   return env
 }
@@ -154,10 +163,12 @@ async function serverEnv(toolchain) {
 /**
  * Install rls-preview, rust-src, rust-analysis
  * @param {string} toolchain
+ * @param {string} [cwd]
  */
-async function installRlsComponents(toolchain) {
+async function installRlsComponents(toolchain, cwd) {
+  const toolchainArg = toolchain && `--toolchain ${toolchain}` || ''
   try {
-    await exec(`rustup component add rls-preview --toolchain ${toolchain}`)
+    await exec(`rustup component add rls-preview ${toolchainArg}`, { cwd })
   } catch (e) {
     let suggestedVersion
     if (toolchain.startsWith('nightly')) {
@@ -179,17 +190,19 @@ async function installRlsComponents(toolchain) {
         onDidClick: () => atom.config.set('ide-rust.rlsToolchain', suggestedVersion)
       })
     }
-    atom.notifications.addError(`\`rls-preview\` was not found on \`${toolchain}\``, note)
+    atom.notifications
+      .addError(`\`rls\` was not found on \`${toolchain || 'the default toolchain'}\``, note)
     throw e
   }
 
   try {
-    await exec(`rustup component add rust-src --toolchain ${toolchain}`)
-    await exec(`rustup component add rust-analysis --toolchain ${toolchain}`)
+    await exec(`rustup component add rust-src ${toolchainArg}`, { cwd })
+    await exec(`rustup component add rust-analysis ${toolchainArg}`, { cwd })
   } catch (e) {
-    atom.notifications.addError(`\`rust-src\`/\`rust-analysis\` not found on \`${toolchain}\``, {
-      dismissable: true
-    })
+    atom.notifications
+      .addError(`\`rust-src\`/\`rust-analysis\` not found on \`${toolchain || 'the default toolchain'}\``, {
+        dismissable: true
+      })
     throw e
   }
 }
@@ -219,14 +232,17 @@ let _checkingRls
 /**
  * Check for and install Rls
  * @param {?BusySignalService} busySignalService
+ * @param {string} [cwd]
  * @return {Promise<*>} rls installed
  */
-async function checkRls(busySignalService) {
+async function checkRls(busySignalService, cwd) {
   if (_checkingRls) return _checkingRls
 
   const toolchain = configToolchain()
+  const toolchainArg = toolchain && `--toolchain ${toolchain}` || ""
+
   _checkingRls = (async () => {
-    let { stdout: toolchainList } = await exec(`rustup component list --toolchain ${toolchain}`)
+    let { stdout: toolchainList } = await exec(`rustup component list ${toolchainArg}`, { cwd })
     if (
       toolchainList.search(/^rls.* \((default|installed)\)$/m) >= 0 &&
       toolchainList.search(/^rust-analysis.* \((default|installed)\)$/m) >= 0 &&
@@ -235,7 +251,7 @@ async function checkRls(busySignalService) {
       return // have rls
     }
     // try to install rls
-    const installRlsPromise = installRlsComponents(toolchain)
+    const installRlsPromise = installRlsComponents(toolchain, cwd)
     if (busySignalService) {
       busySignalService.reportBusyWhile(
         `Adding components rls-preview, rust-src, rust-analysis`,
@@ -264,9 +280,10 @@ class RustLanguageClient extends AutoLanguageClient {
     this.config = {
       rlsToolchain: {
         description: 'Sets the toolchain installed using rustup and used to run the Rls.' +
+          ' When blank will use the rustup or system default.' +
           ' For example ***nightly***, ***stable***, ***beta***, or ***nightly-yyyy-mm-dd***.',
         type: 'string',
-        default: 'stable',
+        default: '',
         order: 1
       },
       checkForToolchainUpdates: {
@@ -319,11 +336,14 @@ class RustLanguageClient extends AutoLanguageClient {
   async _promptToUpdateToolchain() {
     if (!atom.config.get('ide-rust.checkForToolchainUpdates')) return
 
-    const confToolchain = configToolchain()
+    const confToolchain = configToolchain() || await rustupDefaultToolchain()
+    if (!confToolchain) return
+
     const dated = confToolchain.match(DATED_REGEX)
     const toolchain = (dated ? dated[1] : confToolchain)
+    const switching = confToolchain !== toolchain
 
-    let { stdout: currentVersion } = await exec(`rustup run ${confToolchain} rustc --version`)
+    let { stdout: currentVersion } = await rustupRun(confToolchain, "rustc --version")
     let newVersion = await fetchLatestDist({ toolchain, currentVersion }).catch(() => false)
     if (!newVersion) return
 
@@ -332,13 +352,13 @@ class RustLanguageClient extends AutoLanguageClient {
       _src: 'ide-rust',
       dismissable: true,
       buttons: [{
-        text: confToolchain === toolchain ? 'Update' : 'Update & Switch',
+        text: switching ? 'Update & Switch' : 'Update' ,
         onDidClick: () => {
           clearIdeRustInfos()
 
           const updatePromise = exec(`rustup update ${toolchain}`)
             // set config in case going from dated -> latest
-            .then(() => atom.config.set('ide-rust.rlsToolchain', toolchain))
+            .then(() => switching && atom.config.set('ide-rust.rlsToolchain', toolchain))
             .then(() => this._checkToolchain())
             .then(() => checkRls())
             .then(() => this._restartLanguageServers(`Updated Rls toolchain`))
@@ -364,12 +384,13 @@ class RustLanguageClient extends AutoLanguageClient {
   /**
    * Checks for rustup, toolchain & rls components
    * If not found prompts to fix & throws error
+   * @param {string} [cwd]
    */
-  async _checkToolchain() {
+  async _checkToolchain(cwd) {
     const toolchain = configToolchain()
 
     try {
-      await exec(`rustup run ${toolchain} rustc --version`)
+      await rustupRun(toolchain, "rustc --version", { cwd })
       clearIdeRustInfos()
     } catch (e) {
       this._handleMissingToolchain(toolchain)
@@ -521,7 +542,15 @@ class RustLanguageClient extends AutoLanguageClient {
         try {
           await this._checkToolchain()
           await checkRls(this.busySignalService)
-          await this._restartLanguageServers(`Switched Rls toolchain to \`${newValue}\``)
+          let toolchainText = newValue && `\`${newValue}\``
+          if (!toolchainText) {
+            try {
+              toolchainText = `default (\`${await rustupDefaultToolchain()}\`)`
+            } catch (e) {
+              toolchainText = "default"
+            }
+          }
+          await this._restartLanguageServers(`Switched Rls toolchain to ${toolchainText}`)
           return this._promptToUpdateToolchain()
         } catch (e) {
           return logErr(e, console.info)
@@ -643,13 +672,18 @@ class RustLanguageClient extends AutoLanguageClient {
     }
 
     try {
-      await this._checkToolchain()
-      await checkRls(this.busySignalService)
-      let toolchain = configToolchain()
-      return logSuspiciousStdout(cp.spawn("rustup", ["run", toolchain, "rls"], {
-        env: await serverEnv(toolchain),
+      await this._checkToolchain(projectPath)
+      await checkRls(this.busySignalService, projectPath)
+      const toolchain = configToolchain()
+      const opts = {
+        env: await serverEnv(toolchain, projectPath),
         cwd: projectPath
-      }))
+      }
+      if (toolchain) {
+        return logSuspiciousStdout(cp.spawn("rustup", ["run", toolchain, "rls"], opts))
+      } else {
+        return logSuspiciousStdout(cp.spawn("rls", opts))
+      }
     } catch (e) {
       throw new Error("failed to start server: " + e)
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -235,9 +235,9 @@
       "dev": true
     },
     "eslint": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.0.0.tgz",
-      "integrity": "sha512-SrrIfcd4tOgsspOKTSwamuTOAMZOUigHQhVMrzNjz4/B9Za6SHQDIocMIyIDfwDgx6MhS15nS6HC8kumCV2qBQ==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.0.1.tgz",
+      "integrity": "sha512-DyQRaMmORQ+JsWShYsSg4OPTjY56u1nCjAmICrE8vLWqyLKxhFXOthwMj1SA8xwfrv0CofLNVnqbfyhwCkaO0w==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "underscore-plus": "^1.7.0"
   },
   "devDependencies": {
-    "eslint": "^6.0.0"
+    "eslint": "^6.0.1"
   },
   "scripts": {
     "test": "eslint lib --max-warnings 0"


### PR DESCRIPTION
This change switches the default toolchain to `''` which will now mean "use rustup/system default toolchain". This allows rustup overrides to be used.

Closes #135