### PR TITLE
Support rustup-less environments

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -87,6 +87,15 @@ async function rustupDefaultToolchain() {
   return stdout.split("-")[0].trim()
 }
 
+async function hasCommand(rustCommand) {
+  try {
+    await exec(`${rustCommand} -V`)
+    return true
+  } catch (e) {
+    return false
+  }
+}
+
 /** @return {?string} developer override of the command to start a Rls instance */
 function rlsCommandOverride() {
   return atom.config.get('ide-rust.rlsCommandOverride')
@@ -242,6 +251,14 @@ async function checkRls(busySignalService, cwd) {
   const toolchainArg = toolchain && `--toolchain ${toolchain}` || ""
 
   _checkingRls = (async () => {
+    if (!await hasCommand("rustup")) {
+      if (await hasCommand("rls")) {
+        return // have system rls without rustup
+      } else {
+        throw new Error("rls & rustup missing")
+      }
+    }
+
     let { stdout: toolchainList } = await exec(`rustup component list ${toolchainArg}`, { cwd })
     if (
       toolchainList.search(/^rls.* \((default|installed)\)$/m) >= 0 &&
@@ -280,14 +297,14 @@ class RustLanguageClient extends AutoLanguageClient {
     this.config = {
       rlsToolchain: {
         description: 'Sets the toolchain installed using rustup and used to run the Rls.' +
-          ' When blank will use the rustup or system default.' +
+          ' When blank will use the rustup/system default.' +
           ' For example ***nightly***, ***stable***, ***beta***, or ***nightly-yyyy-mm-dd***.',
         type: 'string',
         default: '',
         order: 1
       },
       checkForToolchainUpdates: {
-        description: 'Check on startup & periodically for toolchain updates, prompting to install if available',
+        description: 'Check on startup & periodically for rustup toolchain updates, prompting to install if available.',
         type: 'boolean',
         default: true,
         order: 2
@@ -335,6 +352,12 @@ class RustLanguageClient extends AutoLanguageClient {
   // check for toolchain updates if installed & not dated
   async _promptToUpdateToolchain() {
     if (!atom.config.get('ide-rust.checkForToolchainUpdates')) return
+
+    if (!await hasCommand("rustup")) {
+      atom.config.set('ide-rust.checkForToolchainUpdates', false)
+      this._handleMissingRustup()
+      return
+    }
 
     const confToolchain = configToolchain() || await rustupDefaultToolchain()
     if (!confToolchain) return
@@ -635,7 +658,7 @@ class RustLanguageClient extends AutoLanguageClient {
       return
     }
 
-    if (!this._periodicUpdateChecking) {
+    if (!this._periodicUpdateChecking && await hasCommand("rustup")) {
       // if haven't started periodic checks for updates yet start now
       let periodicUpdateTimeoutId
       const periodicUpdate = async () => {
@@ -657,9 +680,7 @@ class RustLanguageClient extends AutoLanguageClient {
 
     let cmdOverride = rlsCommandOverride()
     if (cmdOverride) {
-      if (!this._warnedAboutRlsCommandOverride && cmdOverride !== 'rls') {
-        // Don't warn if literally 'rls' as this is a workaround for no-rustup environments
-        // TODO: Remove !== 'rls' check once better no-rustup support is in
+      if (!this._warnedAboutRlsCommandOverride) {
         clearIdeRustInfos()
         atom.notifications.addInfo(`Using rls command \`${cmdOverride}\``)
         this._warnedAboutRlsCommandOverride = true


### PR DESCRIPTION
This change allows ide-rust to be used without rustup. The toolchain should be set to `''` which is the new default. Note: Update checking isn't supported without rustup.

Closes #115