### PR TITLE
Kill rls processes instead of awaiting shutdown

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -646,6 +646,12 @@ class RustLanguageClient extends AutoLanguageClient {
       !filePath.includes('/target/release/')
   }
 
+  // Rls can run a long time before gracefully shutting down, so it's better to
+  // kill servers as the cargo builds should be kill-safe
+  shutdownServersGracefully() {
+    return false
+  }
+
   serversSupportDefinitionDestinations() {
     return true
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,7 +85,7 @@
       "dev": true
     },
     "atom-languageclient": {
-      "version": "github:alexheretic/atom-languageclient#ea4c49d7523becb373ca9066e2a6ad5f0888bc81",
+      "version": "github:alexheretic/atom-languageclient#163f729a3048038e8f674bf4c0056bbee04b9062",
       "from": "github:alexheretic/atom-languageclient#build",
       "requires": {
         "fuzzaldrin-plus": "^0.6.0",
@@ -101,13 +101,6 @@
       "requires": {
         "sb-fs": "^4.0.0",
         "semver": "^6.0.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.0.0.tgz",
-          "integrity": "sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ=="
-        }
       }
     },
     "balanced-match": {
@@ -196,6 +189,14 @@
         "semver": "^5.5.0",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        }
       }
     },
     "debug": {
@@ -276,6 +277,14 @@
         "strip-json-comments": "^2.0.1",
         "table": "^5.2.3",
         "text-table": "^0.2.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        }
       }
     },
     "eslint-scope": {
@@ -406,9 +415,9 @@
       }
     },
     "flatted": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.0.tgz",
-      "integrity": "sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
+      "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
       "dev": true
     },
     "fs.realpath": {
@@ -843,10 +852,9 @@
       }
     },
     "semver": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-      "dev": true
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.1.2.tgz",
+      "integrity": "sha512-z4PqiCpomGtWj8633oeAdXm1Kn1W++3T8epkZYnwiVgIYIJ0QHszhInYSJTYxebByQH7KVCEAn8R9duzZW2PhQ=="
     },
     "shebang-command": {
       "version": "1.2.0",


### PR DESCRIPTION
Rls is fine with being killed and quick kills provide a nicer experience.

Required upstream changes (now included in fork): https://github.com/atom/atom-languageclient/pull/269

Closes #134