### PR TITLE
Update atom-languageclient to use rimraf for building

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -121,7 +121,7 @@
       "dev": true
     },
     "atom-languageclient": {
-      "version": "github:alexheretic/atom-languageclient#db8812573ca741542b60464244598fffe455297f",
+      "version": "github:alexheretic/atom-languageclient#9965763faba50bad6c704297345acbfa02cc1c4d",
       "from": "github:alexheretic/atom-languageclient#build",
       "requires": {
         "fuzzaldrin-plus": "^0.6.0",


### PR DESCRIPTION
Relates to #159 