### PR TITLE
Add snippets for eprint, eprintln, todo, unimplemented, and unreachable

### DIFF
--- a/snippets/rust.cson
+++ b/snippets/rust.cson
@@ -21,6 +21,12 @@
       \t$2
       }
     '''
+  'eprint':
+    'prefix': 'eprint'
+    'body': 'eprint!("${1:{${2::?}\\}}", ${3});'
+  'eprintln':
+    'prefix': 'eprintln'
+    'body': 'eprintln!("${1:{${2::?}\\}}", ${3});'
   'fn':
     'prefix': 'fn'
     'body': '''
@@ -124,6 +130,9 @@
       \t}
       }
     '''
+  'todo':
+    'prefix': 'todo'
+    'body': 'todo!($1)$2'
   'trait':
     'prefix': 'trait'
     'body': '''
@@ -134,6 +143,12 @@
   'type':
     'prefix': 'type'
     'body': 'type ${1:TypeName} = ${2:TypeName};'
+  'unimplemented':
+    'prefix': 'unimplemented'
+    'body': 'unimplemented!($1)$2'
+  'unreachable':
+    'prefix': 'unreachable'
+    'body': 'unreachable!($1)$2'
   'warn':
     'prefix': 'warn'
     'body': '#[warn(${1:lint})]'


### PR DESCRIPTION
Thanks for maintaining this plugin! I'm the person who added the snippets in #112.

Rust has added many new features since those snippets were first created in the `language-rust` plugin. We now have `eprint` and `eprintln` for printing to stderr, and `todo` as a substitute for `unimplemented`. I added snippets for each of those and for `unreachable`/`unimplemented` as well since both of those are very useful. 

The snippets in the file are in alphabetical order, so I made my changes to keep that consistent.

These are snippets I've had in my snippets file for a while and I hope others will find them as useful as I have. :) 