### PR TITLE
Workaround missing markdown syntax highlighting

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -572,19 +572,56 @@ class RustLanguageClient extends AutoLanguageClient {
     return provide
   }
 
-  // Workaround #133 that affects stable rust 1.35.0
-  async getCodeFormat(...args) {
-    const edits = await super.getCodeFormat(...args)
-    for (const edit of edits) {
-      const end = edit && edit.oldRange && edit.oldRange.end
-      if (end && end.column > 18e18) {
-        end.row += 1
-        end.column = 0
-        edit.newText += (process.platform === "win32" ? "\r\n" : "\n")
+  /**
+   * Extend base-class to workaround the limited markdown support.
+   * @param {TextEditor} editor
+   * @param {Point} point
+   * @returns {Promise<atomIde.Datatip | null>}
+   */
+  async getDatatip(editor, ...args) {
+    let datatip = await super.getDatatip(editor, ...args)
+    try {
+      if (datatip) {
+        datatip.markedStrings = datatip.markedStrings
+          .flatMap(m => {
+            if (!m.grammar && m.type === "markdown" && m.value) {
+              return convertMarkdownToSnippets(m.value)
+            } else {
+              return m
+            }
+          })
+          .filter(m => m.value)
       }
+    } catch (e) {
+      console.error("Error processing datatip", e)
     }
-    return edits
+    return datatip
   }
+}
+
+/**
+ * Convert "foo\n```rust\nHashSet<u32, String>\n```\nbar"
+ * to [{type: "markdown", value: "foo"}, {type:"snippet", value: "HashSet<u32, String>", ...}, ...]
+ * @param {string} value
+ * @returns {object[]}
+ */
+function convertMarkdownToSnippets(value) {
+  // even indices are text, odds are rust snippets
+  return value.split(/\s*```rust\s*((?:.|\s)+?)\s*```/)
+    .map((bit, index) => {
+      if (index % 2 == 0) {
+        return {
+          type: "markdown",
+          value: bit,
+        }
+      } else {
+        return {
+          type: "snippet",
+          grammar: atom.grammars.grammarForScopeName("source.rust"),
+          value: bit,
+        }
+      }
+    })
 }
 
 // override windows specific implementations


### PR DESCRIPTION
Convert rust-analyzer datatip/hover responses ```` ```rust\ncode\n``` ```` into text & rust-snippets of `code` to allow syntax highlighting of these snippets.

This presumably is a flaw in atom-ide-ui not highlighting markdown.

![](https://user-images.githubusercontent.com/2331607/81738139-2202d080-9491-11ea-887d-79d8e092212f.png)

Remove old rls format workaround.

Resolves #158