### PR TITLE
Support some standard code actions, filter out rust-analyzer custom ones

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -182,7 +182,7 @@ async function serverEnv(toolchain, cwd) {
   env.RUST_BACKTRACE = env.RUST_BACKTRACE || "1"
 
   // if (!env.RUST_LOG && atom.config.get('core.debugLSP')) {
-  //   env.RUST_LOG = 'rls=warn,rls::build=info'
+  //   env.RUST_LOG = 'info'
   // }
 
   try {
@@ -505,9 +505,9 @@ class RustLanguageClient extends AutoLanguageClient {
       !filePath.includes('/target/release/')
   }
 
-  // Killing servers is faster and less likely to get stuck.
+  // Killing servers is faster and less likely to get stuck, but let's see if rust-analyzer deserves grace...
   shutdownServersGracefully() {
-    return false
+    return true
   }
 
   // Can click through to out-of-project files.
@@ -575,6 +575,24 @@ class RustLanguageClient extends AutoLanguageClient {
 
     return provide
   }
+
+  /**
+   * Hide unsupported rust-analyzer custom actions
+   * @param {(ls.Command | ls.CodeAction)[]} actions
+   * @returns {(ls.Command | ls.CodeAction)[]} filtered actions
+   */
+  filterCodeActions(actions) {
+    return actions.filter(a => !a.command || a.command.command !== "rust-analyzer.applySourceChange")
+  }
+
+  // /**
+  //  * TODO: Handle rust-analyzer custom actions
+  //  * @param {(ls.Command | ls.CodeAction)} action
+  //  * @returns {Promise<boolean>} continue with default handling
+  //  */
+  // async onApplyCodeActions(action) {
+  //   return true
+  // }
 
   /**
    * Extend base-class to workaround the limited markdown support.

--- a/package-lock.json
+++ b/package-lock.json
@@ -121,13 +121,13 @@
       "dev": true
     },
     "atom-languageclient": {
-      "version": "github:alexheretic/atom-languageclient#5d4ec6ce0928f009861e75c06e920182eed034d0",
+      "version": "github:alexheretic/atom-languageclient#5fb64f8f547f0ff90204410e50a6cd171b560656",
       "from": "github:alexheretic/atom-languageclient#build",
       "requires": {
         "fuzzaldrin-plus": "^0.6.0",
-        "vscode-jsonrpc": "4.0.0",
-        "vscode-languageserver-protocol": "3.12.0",
-        "vscode-languageserver-types": "3.12.0"
+        "vscode-jsonrpc": "5.0.1",
+        "vscode-languageserver-protocol": "3.15.3",
+        "vscode-languageserver-types": "3.15.1"
       }
     },
     "atom-package-deps": {
@@ -1156,30 +1156,23 @@
       "dev": true
     },
     "vscode-jsonrpc": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz",
-      "integrity": "sha512-perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg=="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-5.0.1.tgz",
+      "integrity": "sha512-JvONPptw3GAQGXlVV2utDcHx0BiY34FupW/kI6mZ5x06ER5DdPG/tXWMVHjTNULF5uKPOUUD0SaXg5QaubJL0A=="
     },
     "vscode-languageserver-protocol": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.12.0.tgz",
-      "integrity": "sha512-evY6hmyzLnwQrqlQWPrNBq1z8wrSNjLesmgPzeS6Zv11mVS5UJRel26hbM/DH5tHdn45huNzRW0eFHRmIm8LpA==",
+      "version": "3.15.3",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.3.tgz",
+      "integrity": "sha512-zrMuwHOAQRhjDSnflWdJG+O2ztMWss8GqUUB8dXLR/FPenwkiBNkMIJJYfSN6sgskvsF0rHAoBowNQfbyZnnvw==",
       "requires": {
-        "vscode-jsonrpc": "^3.6.2",
-        "vscode-languageserver-types": "^3.12.0"
-      },
-      "dependencies": {
-        "vscode-jsonrpc": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-3.6.2.tgz",
-          "integrity": "sha512-T24Jb5V48e4VgYliUXMnZ379ItbrXgOimweKaJshD84z+8q7ZOZjJan0MeDe+Ugb+uqERDVV8SBmemaGMSMugA=="
-        }
+        "vscode-jsonrpc": "^5.0.1",
+        "vscode-languageserver-types": "3.15.1"
       }
     },
     "vscode-languageserver-types": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.12.0.tgz",
-      "integrity": "sha512-UxqnpzBToPO7Mi2tr/s5JeyPOSKSJtLB8lIdxCg9ZNdvP2cU8wS7iTDtwQKz91Ne4CUmTdf85ddR5SIZKXmMjQ=="
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.15.1.tgz",
+      "integrity": "sha512-+a9MPUQrNGRrGU630OGbYVQ+11iOIovjCkqxajPa9w57Sd5ruK8WQNsslzpa0x/QJqC8kRc2DUxWjIFwoNm4ZQ=="
     },
     "which": {
       "version": "2.0.2",


### PR DESCRIPTION
In my updated atom-languageclient fork I've added the ability to filter & to custom handle codeActions. In this PR we'll start supporting the more standard / simple code actions.

![](https://user-images.githubusercontent.com/2331607/81757303-5937a880-94b6-11ea-906e-eb5ca9fff15d.gif)


The custom `rust-analyzer.applySourceChange` actions are not yet supported (and so not offered) but we now have a scaffold to implement custom handling in future using `onApplyCodeActions`.