### PR TITLE
fix: kill rust-analyzer fast without waiting for the close response from

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -477,8 +477,8 @@ class RustLanguageClient extends AutoLanguageClient {
       !filePath.includes('/target/release/')
   }
 
-  // Killing servers is faster and less likely to get stuck, but let's see if rust-analyzer deserves grace...
-  shutdownGracefully = true
+  // Kill servers fast (#196)
+  shutdownGracefully = false
 
   async startServerProcess(projectPath) {
     if (shouldIgnoreProjectPath(projectPath)) {


### PR DESCRIPTION
Fixes #196 