### PR TITLE
Configure rust-analyzer with project-specific config files

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -452,12 +452,15 @@ class RustLanguageClient extends AutoLanguageClient {
     // Don't build straight after initialize, wait for first `workspace/didChangeConfiguration`
     params.initializationOptions.omitInitBuild = true
 
-    try {
-        let rlsConfigPath = path.join(projectPath, "rust-analyzer.json")
-        let options = fs.readFileSync(rlsConfigPath)
-        Object.assign(params.initializationOptions, JSON.parse(options))
-    } catch(e) {
-        console.warn("Could not read config file")
+    let rlsConfigPath = path.join(projectPath, "rust-analyzer.json")
+
+    if (fs.existsSync(rlsConfigPath)) {
+        try {
+            let options = fs.readFileSync(rlsConfigPath)
+            Object.assign(params.initializationOptions, JSON.parse(options))
+        } catch(e) {
+            console.warn("Error reading config file\n", e)
+        }
     }
 
     return params

--- a/lib/index.js
+++ b/lib/index.js
@@ -452,9 +452,13 @@ class RustLanguageClient extends AutoLanguageClient {
     // Don't build straight after initialize, wait for first `workspace/didChangeConfiguration`
     params.initializationOptions.omitInitBuild = true
 
-    let rlsConfigPath = path.join(projectPath, "rust-analyzer.json")
-    let options = fs.readFileSync(rlsConfigPath)
-    Object.assign(params.initializationOptions, JSON.parse(options))
+    try {
+        let rlsConfigPath = path.join(projectPath, "rust-analyzer.json")
+        let options = fs.readFileSync(rlsConfigPath)
+        Object.assign(params.initializationOptions, JSON.parse(options))
+    } catch(e) {
+        console.warn("Could not read config file")
+    }
 
     return params
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -459,7 +459,7 @@ class RustLanguageClient extends AutoLanguageClient {
             let options = fs.readFileSync(rlsConfigPath)
             Object.assign(params.initializationOptions, JSON.parse(options))
         } catch(e) {
-            console.warn("Error reading config file\n", e)
+            console.error("Error reading config file\n", e)
         }
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 const cp = require("child_process")
 const os = require("os")
+const fs = require("fs")
 const path = require("path")
 const { CompositeDisposable, Disposable } = require("atom")
 const { AutoLanguageClient } = require("atom-languageclient")
@@ -450,6 +451,11 @@ class RustLanguageClient extends AutoLanguageClient {
     params.initializationOptions = params.initializationOptions || {}
     // Don't build straight after initialize, wait for first `workspace/didChangeConfiguration`
     params.initializationOptions.omitInitBuild = true
+
+    let rlsConfigPath = path.join(projectPath, "rust-analyzer.json")
+    let options = fs.readFileSync(rlsConfigPath)
+    Object.assign(params.initializationOptions, JSON.parse(options))
+
     return params
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -459,7 +459,7 @@ class RustLanguageClient extends AutoLanguageClient {
             let options = fs.readFileSync(rlsConfigPath)
             Object.assign(params.initializationOptions, JSON.parse(options))
         } catch(e) {
-            console.error("Error reading config file\n", e)
+            atom.notifications.addError("Error reading rust-analyzer config file\n", e)
         }
     }
 


### PR DESCRIPTION
Allow a user to configure the rust-analyzer server with a config file similar to the previously used `rls.toml`.

Closes #166