### PR TITLE
Remove duplicate lint warnings

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,9 +33,6 @@ jobs:
           apm install --production
           npm install --only=dev
 
-      - name: Run tests 👩🏾‍💻
-        run: npm run lint
-
   Lint:
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     name: ${{ matrix.os }} - Atom ${{ matrix.atom_channel }}


### PR DESCRIPTION
Each job currently produces its own warning, resulting in 4 identical warnings. It seems redundant to include the lint step in the test CI jobs.