### PR TITLE
Move config files to avoid cluttering project root

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,14 @@ However, you may wish to install `rustup` with your OS package manager instead o
 
 ## Configure rust-analyzer
 
-**rust-analyzer** settings can be stored in a JSON file located at `.ide-rust/rust-analyzer.json` relative to the project directory.
+**rust-analyzer** settings can be stored in a JSON file in the project directory.
+
+It first looks for `rust-analyzer.json`.
+If the file does not exists, it then checks `.config/rust-analyzer.json`.
 
 ### Example
 
-`.ide-rust/rust-analyzer.json`
+`.config/rust-analyzer.json`
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -34,6 +34,27 @@ NOTE: On Windows, you can install it using [choco](https://chocolatey.org/instal
 No other packages or manual setup is required as these will be handled with user prompts after install.
 However, you may wish to install `rustup` with your OS package manager instead of following prompts to install via [rustup.rs](https://rustup.rs).
 
+## Configure rust-analyzer
+
+**rust-analyzer** settings can be stored in a JSON file located at `.ide-rust/rust-analyzer.json` relative to the project directory.
+
+### Example
+
+`.ide-rust/rust-analyzer.json`
+
+```json
+{
+    "cargo": {
+        "loadOutDirsFromCheck": true,
+    },
+    "procMacro": {
+        "enable": true,
+    }
+}
+```
+
+Refer to the [rust-analyzer User Manual](https://rust-analyzer.github.io/manual.html#configuration) for the supported config options.
+
 ## Commands
 
 - `ide-rust:restart-all-language-servers` Restart all currently active Rls processes

--- a/lib/index.js
+++ b/lib/index.js
@@ -472,7 +472,7 @@ class RustLanguageClient extends AutoLanguageClient {
     // Don't build straight after initialize, wait for first `workspace/didChangeConfiguration`
     params.initializationOptions.omitInitBuild = true
 
-    let rlsConfigPath = path.join(projectPath, ".rust-ide/rust-analyzer.json")
+    let rlsConfigPath = path.join(projectPath, ".ide-rust/rust-analyzer.json")
 
     if (fs.existsSync(rlsConfigPath)) {
         try {

--- a/lib/index.js
+++ b/lib/index.js
@@ -472,7 +472,7 @@ class RustLanguageClient extends AutoLanguageClient {
     // Don't build straight after initialize, wait for first `workspace/didChangeConfiguration`
     params.initializationOptions.omitInitBuild = true
 
-    let rlsConfigPath = path.join(projectPath, ".ide-rust/rust-analyzer.json")
+    let rlsConfigPath = path.join(projectPath, "rust-analyzer.json")
 
     if (fs.existsSync(rlsConfigPath)) {
         try {

--- a/lib/index.js
+++ b/lib/index.js
@@ -472,7 +472,7 @@ class RustLanguageClient extends AutoLanguageClient {
     // Don't build straight after initialize, wait for first `workspace/didChangeConfiguration`
     params.initializationOptions.omitInitBuild = true
 
-    let rlsConfigPath = path.join(projectPath, "rust-analyzer.json")
+    let rlsConfigPath = path.join(projectPath, ".rust-ide/rust-analyzer.json")
 
     if (fs.existsSync(rlsConfigPath)) {
         try {

--- a/lib/index.js
+++ b/lib/index.js
@@ -474,6 +474,10 @@ class RustLanguageClient extends AutoLanguageClient {
 
     let rlsConfigPath = path.join(projectPath, "rust-analyzer.json")
 
+    if (!fs.existsSync(rlsConfigPath)) {
+        rlsConfigPath = path.join(projectPath, ".config/rust-analyzer.json")
+    }
+
     if (fs.existsSync(rlsConfigPath)) {
         try {
             let options = fs.readFileSync(rlsConfigPath)


### PR DESCRIPTION
Thanks for your help with the addition of the config file. I based it off how the `rls.toml` file used to work, where the file was found in the root directory of the project. However, I think it would be better to store config files in a hidden directory, similar to how VSCode does.