### PR TITLE
Change the lint CI job name to be more descriptive

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,7 +35,7 @@ jobs:
 
   Lint:
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
-    name: ${{ matrix.os }} - Atom ${{ matrix.atom_channel }}
+    name: ${{ matrix.os }} - Lint
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
Changes the name from `ubuntu-latest - Atom` to `ubuntu-latest - Lint`