### PR TITLE
Add `cargo +nightly fmt` example to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,11 @@ However, you may wish to install `rustup` with your OS package manager instead o
 It first looks for `rust-analyzer.json`.
 If the file does not exists, it then checks `.config/rust-analyzer.json`.
 
-### Example
+Refer to the [rust-analyzer User Manual](https://rust-analyzer.github.io/manual.html#configuration) for the supported config options.
 
-`.config/rust-analyzer.json`
+### Examples
+
+#### enable proc-macro support (from the [rust-analyzer User Manual](https://rust-analyzer.github.io/manual.html#configuration))
 
 ```json
 {
@@ -56,7 +58,15 @@ If the file does not exists, it then checks `.config/rust-analyzer.json`.
 }
 ```
 
-Refer to the [rust-analyzer User Manual](https://rust-analyzer.github.io/manual.html#configuration) for the supported config options.
+#### configure rust-fmt
+
+```json
+{
+    "rustfmt": {
+        "overrideCommand": "cargo +nightly fmt"
+    }
+}
+```
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Refer to the rust-analyzer [User Manual](https://rust-analyzer.github.io/manual.
 ```json
 {
     "rustfmt": {
-        "overrideCommand": "cargo +nightly fmt"
+        "extraArgs": ["+nightly"]
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ However, you may wish to install `rustup` with your OS package manager instead o
 It first looks for `rust-analyzer.json`.
 If the file does not exists, it then checks `.config/rust-analyzer.json`.
 
-Refer to the [rust-analyzer User Manual](https://rust-analyzer.github.io/manual.html#configuration) for the supported config options.
+Refer to the rust-analyzer [User Manual](https://rust-analyzer.github.io/manual.html#configuration) for the supported config options.
 
 ### Examples
 
-#### enable proc-macro support (from the [rust-analyzer User Manual](https://rust-analyzer.github.io/manual.html#configuration))
+#### enable proc-macro support (from the [User Manual](https://rust-analyzer.github.io/manual.html#configuration))
 
 ```json
 {


### PR DESCRIPTION
Adds an example configuration to use the nightly toolchain when formatting.