### PR TITLE
Remove unused `rls.toml` code

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -427,19 +427,6 @@ class RustLanguageClient extends AutoLanguageClient {
     // Get required dependencies
     await require("atom-package-deps").install("ide-rust")
 
-    // // Watch rls.toml file changes -> update rls
-    // this.disposables.add(atom.project.onDidChangeFiles(events => {
-    //   if (_.isEmpty(this.projects)) return
-    //
-    //   for (const event of events) {
-    //     if (event.path.endsWith('rls.toml')) {
-    //       let projectPath = Object.keys(this.projects).find(key => event.path.startsWith(key))
-    //       let rlsProject = projectPath && this.projects[projectPath]
-    //       if (rlsProject) rlsProject.sendRlsTomlConfig()
-    //     }
-    //   }
-    // }))
-
     // watch config toolchain updates -> check for updates if enabling
     this.disposables.add(
       atom.config.onDidChange("ide-rust.checkForToolchainUpdates", ({ newValue: enabled }) => {
@@ -499,8 +486,6 @@ class RustLanguageClient extends AutoLanguageClient {
       delete this.projects[server.projectPath]
       this._refreshActiveOverrides()
     })
-
-    // project.sendRlsTomlConfig()
 
     this._refreshActiveOverrides()
   }

--- a/lib/rust-project.js
+++ b/lib/rust-project.js
@@ -1,6 +1,5 @@
 const path = require("path")
 const fs = require("fs")
-const toml = require("toml")
 const _ = require("underscore-plus")
 
 /**
@@ -86,39 +85,6 @@ class RustProject {
       busyMessage.lastProgressMessage = message
       busyMessage.lastProgressTitle = title
     }
-  }
-
-  // Send rls.toml as `workspace/didChangeConfiguration` message (or default if no rls.toml)
-  sendRlsTomlConfig() {
-    const rlsTomlPath = path.join(this.server.projectPath, "rls.toml")
-
-    fs.readFile(rlsTomlPath, (err, data) => {
-      const config = this.defaultConfig()
-      if (!err) {
-        try {
-          Object.assign(config, toml.parse(data))
-        } catch (e) {
-          console.warn(`Failed to read ${rlsTomlPath}`, e)
-        }
-      }
-
-      if (_.isEqual(config, this._lastSentConfig)) {
-        return
-      }
-
-      this.server.connection.didChangeConfiguration({
-        settings: {
-          rust: config,
-        },
-      })
-      this._lastSentConfig = config
-    })
-  }
-
-  // Default Rls config according to package settings & Rls defaults
-  /* eslint-disable-next-line class-methods-use-this */
-  defaultConfig() {
-    return {}
   }
 }
 


### PR DESCRIPTION
Removes unused code related to old `rls.toml` config files.