### PR TITLE
Fixed markdown in datatips

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -459,6 +459,12 @@ class RustLanguageClient extends AutoLanguageClient {
     // Don't build straight after initialize, wait for first `workspace/didChangeConfiguration`
     params.initializationOptions.omitInitBuild = true
 
+    // let the server know we support markdown
+    params.capabilities.general.markdown = {
+      "parser": "marked"
+    };
+    params.capabilities.textDocument.hover.contentFormat = ["markdown", "plaintext"];
+
     let rlsConfigPath = path.join(projectPath, "rust-analyzer.json")
 
     if (!fs.existsSync(rlsConfigPath)) {


### PR DESCRIPTION
The datatips shown on hover were just showing malformed plaintext documentation rather than rendered markdown. This should fix it.